### PR TITLE
Version 0.3.0: Fix - Event Overlay

### DIFF
--- a/display/lib/server/overlayHandler.js
+++ b/display/lib/server/overlayHandler.js
@@ -105,7 +105,7 @@ export function setPlaceName(place, name) {
     if (place > data.config.overlay.placements || place < 0) return false;
 
     // Check if name is in the team_info.json - if not, return
-    if (!teamInfo[name]) return false;
+    if (!teamInfo[name] && name != "NONE") return false;
 
     // get the score
     let score = data.placements[place - 1].score;


### PR DESCRIPTION
Fix an issue where putting "NONE" in `placeName` for the overlay, when in combination with a `place` field, will not clear the overlay.