### PR TITLE
Version 0.5.0 - Right-hand side Overlay

### DIFF
--- a/display/app/api/overlay/route.ts
+++ b/display/app/api/overlay/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse, type NextRequest } from "next/server";
-import {resetOverlay, setGameNumber, getGameNumber, getOverlayData, setGame, setStatusDisplayOptions, setPlacementsDisplayOptions, getPlacements, setPlaceName, setPlaceScore} from '@/lib/server/overlayHandler';
+import {resetOverlay, setGameNumber, getGameNumber, getOverlayData, setGame, setStatusDisplayOptions, setPlacementsDisplayOptions, getPlacements, setPlaceName, setPlaceScore, setForcedSideOptions} from '@/lib/server/overlayHandler';
 import { notify } from "@/lib/transmitter/listeners";
 
 export function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     
     // Read from queries
+    const forceOverlaySide = searchParams.get('forcedSide')
     const gameNoUpdate = searchParams.get('gameNo')
     const gameUpdate = searchParams.get('game')
 
@@ -18,9 +19,13 @@ export function GET(request: NextRequest) {
     const placementsVisibleUpdate = searchParams.get('placements')
     const reset = searchParams.get('reset');
 
+
     // Current info
     let currentPlacements = getPlacements();
     let changed = false;
+
+    // Forced Overlay Sides
+    if (forceOverlaySide) changed = setForcedSideOptions(forceOverlaySide);
   
     // Game Number
     if (gameNoUpdate) {

--- a/display/app/globals.css
+++ b/display/app/globals.css
@@ -36,8 +36,10 @@ body {
 .transition-width-fast { transition: width 0.5s ease; }
 
 /* Slides */
+.slide-left-in { transform: translateX(0); } 
 .slide-right-in { transform: translateX(0); } 
 .slide-left-out { transform: translateX(-50%); }
+.slide-right-out { transform: translateX(150%); }
 
 .slide-up-out { transform: translateY(-100%); }
 .slide-up-in { transform: translateY(0); }

--- a/display/app/overlay/overlay.module.css
+++ b/display/app/overlay/overlay.module.css
@@ -3,6 +3,12 @@
     margin-top: 50px;
 }
 
+.main_right {
+    position: absolute;
+    top: 50px;
+    right: 50px;
+}
+
 .status {
     display: flex;
     margin-bottom: 5px;

--- a/display/app/overlay/page.tsx
+++ b/display/app/overlay/page.tsx
@@ -37,7 +37,8 @@ export default function Page() {
             score: -1
         }],
         statusVisible: true,
-        placementsVisible: true
+        placementsVisible: true,
+        forcedSide: "none"
     });
 
     useEffect(() => {
@@ -58,13 +59,18 @@ export default function Page() {
         return () => evtSrc.close();
     }, []);
 
+    const getSide = () => {
+        if (overlayData.forcedSide != "none") return overlayData.forcedSide;
+        return displayOption || "left";
+    }
+
     const transitionClassNames = (status: boolean) => {
         if (status) {
-            if (displayOption == "right") return "transition-slide slide-left-in"
+            if (getSide() == "right") return "transition-slide slide-left-in"
             return "transition-slide slide-right-in"
         }
 
-        if (displayOption == "right") return "transition-slide slide-right-out"
+        if (getSide() == "right") return "transition-slide slide-right-out"
         return "transition-slide slide-left-out"
     }
 
@@ -103,7 +109,7 @@ export default function Page() {
     }
 
     return (
-        <div className={displayOption == "right" ? styles.main_right : styles.main}>
+        <div className={getSide() == "right" ? styles.main_right : styles.main}>
             <div className={transitionClassNames(overlayData.statusVisible)}>
                 <div className={styles.status}>
                     <div className={styles.status_icon} style={{"--bg-colour": colours.secondary} as React.CSSProperties}><img src={"/icon-event.png"}/></div>

--- a/display/app/overlay/page.tsx
+++ b/display/app/overlay/page.tsx
@@ -12,6 +12,7 @@ import { hexToRGBA } from '@/lib/utils/utils';
 import teamInfo from '@/data/team_info.json';
 import { getGameLogoPath } from "@/lib/client/gameInfo";
 import { getConfig, getConfigColours } from "@/lib/client/config";
+import { useSearchParams } from "next/navigation";
 
 const config = await getConfig();
 const colours = await getConfigColours();
@@ -23,11 +24,13 @@ interface ITeamPlacement {
 }
 
 export default function Page() {
+    const searchParams = useSearchParams();
+    const displayOption = searchParams.get('display');
+
     const [overlayData, setOverlayData] = useState({
         gameNumber: 1,
         multiplier: "x1.0",
         game: "DEFAULT",
-        gameLogo: "/game_logos/Default.png",
         placements: [{
             place: 0,
             name: "",
@@ -55,7 +58,15 @@ export default function Page() {
         return () => evtSrc.close();
     }, []);
 
-    if (!config) return null;
+    const transitionClassNames = (status: boolean) => {
+        if (status) {
+            if (displayOption == "right") return "transition-slide slide-left-in"
+            return "transition-slide slide-right-in"
+        }
+
+        if (displayOption == "right") return "transition-slide slide-right-out"
+        return "transition-slide slide-left-out"
+    }
 
     const headerDisplay = () => {
         // Configure the text
@@ -85,15 +96,15 @@ export default function Page() {
             return (<TeamPlacement key={place.place} place={place.place} name={place.name} score={place.score} scoreLimit={config.overlay.score_limit}/>)
         })
         return (
-            <div className={overlayData.placementsVisible ? "transition-slide slide-right-in" : "transition-slide slide-left-out"}>
+            <div className={transitionClassNames(overlayData.placementsVisible)}>
                 {lst}
             </div>
         )
     }
 
     return (
-        <div className={styles.main}>
-            <div className={overlayData.statusVisible ? "transition-slide slide-right-in" : "transition-slide slide-left-out"}>
+        <div className={displayOption == "right" ? styles.main_right : styles.main}>
+            <div className={transitionClassNames(overlayData.statusVisible)}>
                 <div className={styles.status}>
                     <div className={styles.status_icon} style={{"--bg-colour": colours.secondary} as React.CSSProperties}><img src={"/icon-event.png"}/></div>
                     {headerDisplay()}

--- a/display/lib/server/overlayHandler.js
+++ b/display/lib/server/overlayHandler.js
@@ -37,6 +37,8 @@ export const getGame = () => data.game;
 export const getPlacements = () => data.placements;
 export const getPlacementInfo = (place) => data.placements[place] || {};
 
+export const getForcedSideOptions = () => data.forcedSide;
+
 export const getStatusDisplayOptions = () => data.statusVisible;
 export const getPlacementsDisplayOptions = () => data.placementsVisible;
 
@@ -113,6 +115,14 @@ export function setPlacementsDisplayOptions(option) {
         return true;
     }
     return false;
+}
+
+export function setForcedSideOptions(option) {
+    if (option == "left" || option == "right") data.forcedSide = option;
+    else data.forcedSide = "none";
+
+    save(statePath, data);
+    return true;
 }
 
 /* RESET */

--- a/display/state/defaults/overlay.json
+++ b/display/state/defaults/overlay.json
@@ -4,5 +4,6 @@
     "game": "DEFAULT",
     "placements": [],
     "statusVisible": true,
-    "placementsVisible": true
+    "placementsVisible": true,
+    "forcedSide": "none"
 }


### PR DESCRIPTION
The overlay can now be displayed on the right-hand side of the screen, without the need of moving the actual source.
* This can be done by specifying `display=right` as a search parameter in the URL
* The overlay can also be "forced" to be on a specific side by going through the overlay API with `/api/overlay?forcedSide=X`, where X is either left or right. Anything else will return "none"
